### PR TITLE
Feat/main page/#15 로그인 모달 전역상태로 관리

### DIFF
--- a/frontend/components/header/header.component.tsx
+++ b/frontend/components/header/header.component.tsx
@@ -3,13 +3,17 @@ import Image from "next/image";
 import styles from "styles/Header.module.scss";
 import logo from "public/icon/logo.png";
 import Link from "next/link";
-import { Props } from "./header";
+import LoginModal from "components/modal/loginModal.component";
+import DropDown from "./dropDown";
 import dropDown from "public/icon/dropDown.png";
 import loginUser from "public/icon/loginUser.png";
 import { ImageInfo } from "./header";
-import DropDown from "./dropDown";
+import { Props } from "./header";
+import { useSetRecoilState } from "recoil";
+import { loginModal } from "states/loginModal";
 
-function Header({ setVisible, cookie }: Props) {
+function Header({ cookie }: Props) {
+  const setVisible = useSetRecoilState(loginModal);
   const onClickLogin = () => {
     setVisible(true);
   };
@@ -24,7 +28,7 @@ function Header({ setVisible, cookie }: Props) {
         <h1 className={styles.logoText}>모면</h1>
       </Link>
       <div className={styles.menuContainer}>
-        <Link href='/post/create'>
+        <Link href="/post/create">
           <div className={styles.menuText}>모의면접 모집</div>
         </Link>
         {cookie ? (
@@ -51,6 +55,7 @@ function Header({ setVisible, cookie }: Props) {
           </div>
         )}
       </div>
+      <LoginModal />
     </div>
   );
 }

--- a/frontend/components/header/header.d.ts
+++ b/frontend/components/header/header.d.ts
@@ -4,7 +4,6 @@ export interface Object {
   auth: string;
 }
 export interface Props {
-  setVisible: React.Dispatch<React.SetStateAction<bollean>>;
   cookie: string | undefined;
 }
 

--- a/frontend/components/modal/loginModal.component.tsx
+++ b/frontend/components/modal/loginModal.component.tsx
@@ -5,6 +5,9 @@ import Image from "next/image";
 import modalExit from "public/icon/modalExit.png";
 import github from "public/icon/github.png";
 import { ViewProps, ModalProps } from "./loginModal";
+import { useRecoilState } from "recoil";
+import { loginModal } from "states/loginModal";
+
 Modal.setAppElement("div");
 
 const LoginView = ({ setVisible }: ViewProps) => {
@@ -36,7 +39,8 @@ const LoginView = ({ setVisible }: ViewProps) => {
   );
 };
 
-function LoginModal({ visible, setVisible }: ModalProps) {
+function LoginModal() {
+  const [visible, setVisible] = useRecoilState(loginModal);
   const onCloseMoal = () => {
     setVisible(false);
   };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.39.3",
     "react-modal": "^3.16.1",
+    "recoil": "^0.7.6",
     "sass": "^1.56.1",
     "typescript": "4.8.4"
   },

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,18 +1,22 @@
 import { useState } from "react";
 import type { AppProps } from "next/app";
-import "../styles/globals.css"
+import "../styles/globals.css";
 import {
   Hydrate,
   QueryClient,
   QueryClientProvider,
 } from "@tanstack/react-query";
+import { RecoilRoot } from "recoil";
+
 export default function App({ Component, pageProps }: AppProps) {
   const [queryClient] = useState(() => new QueryClient());
   return (
-    <QueryClientProvider client={queryClient}>
-      <Hydrate state={pageProps.dehydratedState}>
-        <Component {...pageProps} />
-      </Hydrate>
-    </QueryClientProvider>
+    <RecoilRoot>
+      <QueryClientProvider client={queryClient}>
+        <Hydrate state={pageProps.dehydratedState}>
+          <Component {...pageProps} />
+        </Hydrate>
+      </QueryClientProvider>
+    </RecoilRoot>
   );
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,5 +1,4 @@
 import { Suspense, useState } from "react";
-import LoginModal from "components/modal/loginModal.component";
 import styles from "styles/Home.module.scss";
 import Header from "components/header/header.component";
 import HomeHead from "head/home";
@@ -10,12 +9,10 @@ import { GetServerSideProps, NextPage } from "next";
 import { Cookie } from "types/auth";
 
 const Home: NextPage<Posts & Cookie> = ({ posts, cookie }) => {
-  const [visible, setVisible] = useState(false);
   return (
     <div className={styles.main}>
       <HomeHead />
-      <Header setVisible={setVisible} cookie={cookie} />
-      <LoginModal visible={visible} setVisible={setVisible} />
+      <Header cookie={cookie} />
       <Suspense fallback={<div>로딩중</div>}>
         <PostContainer posts={posts} />
       </Suspense>

--- a/frontend/pages/post/create.tsx
+++ b/frontend/pages/post/create.tsx
@@ -1,16 +1,15 @@
-import styles from 'styles/Create.module.css'
+import styles from "styles/Create.module.css";
 import Header from "components/header/header.component";
-import React, {useState} from "react";
+import React from "react";
 import CreatePostForm from "components/createPostForm/createPostForm.component";
-import Head from 'next/head';
-import {GetServerSideProps, NextPage} from "next";
-import {Cookie} from "../../types/auth";
+import Head from "next/head";
+import { GetServerSideProps, NextPage } from "next";
+import { Cookie } from "../../types/auth";
 
-const Create : NextPage<Cookie> = ({cookie}) => {
-  const [visible, setVisible] = useState(false);
-  return(
+const Create: NextPage<Cookie> = ({ cookie }) => {
+  return (
     <div className={styles.createPageContainer}>
-      <Header setVisible={setVisible} cookie={cookie}/>
+      <Header cookie={cookie} />
       <Head>
         <title>모두의 면접</title>
       </Head>
@@ -18,11 +17,11 @@ const Create : NextPage<Cookie> = ({cookie}) => {
         <div className={styles.titleWrapper}>
           <h2> 모의 면접 모집 </h2>
         </div>
-        <CreatePostForm/>
+        <CreatePostForm />
       </div>
     </div>
   );
-}
+};
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const cookie = context.req.cookies.auth ? context.req.cookies.auth : null;
@@ -31,6 +30,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       cookie,
     },
   };
-}
+};
 
-export default Create
+export default Create;

--- a/frontend/states/loginModal.ts
+++ b/frontend/states/loginModal.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const loginModal = atom({
+  key: "loginModalState",
+  default: false,
+});


### PR DESCRIPTION
### issue #15 
### recoil 도입

### 로그인 모달을 전역상태로 관리 함
메인페이지 -> 로그인모달 스테이트 + 로그인 모달 컴포넌트 + 헤더 컴포넌트 
=> 메인페이지 -> 헤더 컴포넌트
모든 페이지에 똑같이 적용됨

### yarn dev시 오류
yarn dev 상태에서 recoil 사용시 오류 메세지 출력
개발 모드에서만 발생하는 문제
https://velog.io/@sj_dev_js/Recoil-Duplicate-atom-key
