### PR TITLE
feat: 백엔드서버, DB 도커라이징 #25

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,26 @@
+# build
+FROM node:16 AS builder
+
+WORKDIR /usr/src/app
+COPY package.json ./
+COPY yarn.lock ./
+RUN yarn install --development
+COPY . .
+
+RUN yarn build
+
+# run
+FROM node:16-alpine
+
+ARG NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
+
+WORKDIR /usr/src/app
+COPY package.json ./
+COPY yarn.lock ./
+RUN yarn install --production
+COPY . .
+COPY --from=builder /usr/src/app/dist ./dist
+
+EXPOSE 8080
+CMD ["node", "dist/main"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  app:
+    container_name: nest-app
+    build:
+      context: .
+    ports:
+      - 8080:8080
+    networks:
+      - common-net
+    depends_on:
+      - mysql
+
+  mysql:
+    container_name: mysql-host
+    image: mysql:8.0
+    env_file:
+      - ./config/.env.production
+    ports:
+      - 3307:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PW}
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - ./init.sql:/data/application/init.sql
+    command: --init-file /data/application/init.sql
+    networks:
+      - common-net
+
+networks:
+  common-net:

--- a/backend/init.sql
+++ b/backend/init.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE IF NOT EXISTS momyeon_db;
+
+USE momyeon_db;


### PR DESCRIPTION
관련 이슈: #25 

## 내용
백엔드 앱 서버, mysql 도커라이징
main 브랜치에 머지 이후 돌려봐야 함

## 설명

### Dockerfile

- 도커 이미지 경량화를 위해 Multi-stage builds 패턴을 적용

- 빌드는 node:16의 development 환경에서, 실행은 node:16 alpine의 production 환경에서 동작

```dockerfile
# build
FROM node:16 AS builder
# 생략..
RUN yarn build

# run
FROM node:16-alpine
# 생략..
RUN yarn install --production
```

### docker-compose.yml

- 백엔드 앱 서버와 mysql의 2개 컨테이너 생성을 위해 docker compose 작성
- 항목별 설명

```yml
version: '3.8'

services:
  app:
    container_name: nest-app
    build:
      context: .
    ports:
      - 8080:8080 # 호스트 : 컨테이너
    networks:
      - common-net # nest-app과 mysql이 공용으로 사용하는 네트워크
    depends_on: # 서비스 시작 순서 디펜던시 설정
      - mysql

  mysql:
    container_name: mysql-host
    image: mysql:8.0
    env_file:   # mysql 루트 비밀번호 숨기기
      - ./config/.env.production
    ports:
      - 3307:3306
    environment:
      MYSQL_ROOT_PASSWORD: ${DB_PW}
    command:  # 한글 관련 설정
      - --character-set-server=utf8mb4
      - --collation-server=utf8mb4_unicode_ci
    volumes:  # 호스트의 파일, 폴더를 컨테이너에 마운트
      - ./init.sql:/data/application/init.sql
    command: --init-file /data/application/init.sql # typeorm 사용을 위해 database 스키마 생성쿼리 실행
    networks:
      - common-net

networks:
  common-net:
```

## 이후 해야할 작업
* main 브랜치에 병합하여 nCloud 인스턴스에 적용해보기
* github actions로 CD 적용하기
* redis 추가하기