### PR TITLE
모의면접 참가자 정보 조회 api 구현

### DIFF
--- a/backend/src/guards/jwtAuth.guard.ts
+++ b/backend/src/guards/jwtAuth.guard.ts
@@ -44,7 +44,7 @@ export class JwtGuard implements CanActivate {
       return true;
     } catch (err) {
       console.error(err);
-      throw new InternalServerErrorException();
+      throw err;
     }
   }
 

--- a/backend/src/interview/interview.controller.ts
+++ b/backend/src/interview/interview.controller.ts
@@ -32,6 +32,11 @@ export class InterviewController {
     return this.interviewService.findOne(+id);
   }
 
+  @Get('members/:interviewId')
+  getMembers(@Param('interviewId') interviewId: string) {
+    return this.interviewService.getMembers(interviewId);
+  }
+
   @Patch(':id')
   update(
     @Param('id') id: string,

--- a/backend/src/interview/interview.module.ts
+++ b/backend/src/interview/interview.module.ts
@@ -6,6 +6,7 @@ import { Interview } from 'src/entities/interview.entity';
 import { Category } from 'src/entities/category.entity';
 import { InterviewCategory } from 'src/entities/interviewCategory.entity';
 import { UserInterview } from 'src/entities/userInterview.entity';
+import { Resume } from 'src/entities/resume.entity';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { UserInterview } from 'src/entities/userInterview.entity';
     TypeOrmModule.forFeature([Category]),
     TypeOrmModule.forFeature([InterviewCategory]),
     TypeOrmModule.forFeature([UserInterview]),
+    TypeOrmModule.forFeature([Resume]),
   ],
   controllers: [InterviewController],
   providers: [InterviewService],

--- a/backend/src/middlewares/appLoger.middleware.ts
+++ b/backend/src/middlewares/appLoger.middleware.ts
@@ -6,7 +6,7 @@ export class AppLoggerMiddleware implements NestMiddleware {
   private logger = new Logger('HTTP');
 
   use(request: Request, response: Response, next: NextFunction): void {
-    const { ip, method, path: url } = request;
+    const { ip, method, originalUrl: url } = request;
     const userAgent = request.get('user-agent') || '';
 
     response.on('close', () => {


### PR DESCRIPTION
 관련 이슈: #52 

## 작업내용
- 디버깅을 위해 logger가 요청받은 original 경로를 출력하도록 수정
- auth guard에서의 에러코드와 메세지가 500 internal 고정이 아닌 상황에 맞게 응답되도록 수정
- 모의면접 참가자 정보 조회 api 구현
  - 하나의 querybuilder로 시도하였으나 join과 select 과정이 복잡해 일단 두 과정으로 나눔.

## 설명

* 모의면접 참가자 id, 닉네임 가져오기
```javascript

const members = await this.userInterviewRepository
      .createQueryBuilder('ui')
      .innerJoinAndSelect(User, 'user', 'ui.userId = user.id')
      .where('ui.interviewId = :id', { id: interviewId })
      .select(['user.id as userId', 'nickname'])
      .getRawMany();
```

* 가져온 id들을 토대로 이력서 정보 가져오기
```javascript
const rawResumes = await this.resumeRepository
      .createQueryBuilder('resume')
      .innerJoinAndSelect(Item, 'item', 'resume.itemId = item.id')
      .where('resume.userId in (:id)', { id: memberIds })
      .select(['resume.userId as userId', 'title', 'content'])
      .getRawMany();
```

* extractResumes(rawResumes) : 이력서 정보 형식 가공하기
* 가공한 이력서 데이터 붙여서 응답하기
```javascript
const resumes = this.extractResumes(rawResumes);

Object.entries(resumes).forEach(([rId, resume]) => {
  const found = members.find((member) => member.userId === +rId);
  found.resume = resume;
});
return { members };
```
