### PR TITLE
Chore/front ssl/#71

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,8 @@
     "react-modal": "^3.16.1",
     "recoil": "^0.7.6",
     "sass": "^1.56.1",
-    "typescript": "4.8.4"
+    "typescript": "4.8.4",
+    "dotenv": "16.0.3"
   },
   "main": "index.js",
   "license": "MIT",

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -3,8 +3,10 @@ const { createServer: http } = require('http');
 const { parse } = require('url');
 const next = require('next');
 const fs = require('fs');
+require('dotenv').config();
 
-const app = next();
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
 const handle = app.getRequestHandler();
 
 const ports = {

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,0 +1,36 @@
+const { createServer: https } = require('https');
+const { createServer: http } = require('http');
+const { parse } = require('url');
+const next = require('next');
+const fs = require('fs');
+
+const app = next();
+const handle = app.getRequestHandler();
+
+const ports = {
+  http: process.env.HTTP_PORT,
+  https: process.env.HTTPS_PORT,
+};
+
+const httpsOptions = {
+  key: fs.readFileSync(process.env.SSL_KEY),
+  cert: fs.readFileSync(process.env.SSL_CRT),
+};
+
+app.prepare().then(() => {
+  http((req, res) => {
+    const parsedUrl = parse(req.url, true);
+    handle(req, res, parsedUrl);
+  }).listen(ports.http, (err) => {
+    if (err) throw err;
+    console.log(`> HTTP: Ready on http://localhost:${ports.http}`);
+  });
+
+  https(httpsOptions, (req, res) => {
+    const parsedUrl = parse(req.url, true);
+    handle(req, res, parsedUrl);
+  }).listen(ports.https, (err) => {
+    if (err) throw err;
+    console.log(`> HTTPS: Ready on https://localhost:${ports.https}`);
+  });
+});


### PR DESCRIPTION
#71 내용으로

##  환경변수 추가사항 `frontend/.env` 
> #포트(맞춰서 수정)
HTTP_PORT=3300
HTTPS_PORT=3000
#인증서 경로(맞춰서 수정)
SSL_KEY=../../cert/private.key
SSL_CRT=../../cert/certificate.crt

## NginX 세팅
1) config 수정(`/etc/nginx/conf.d/default.conf`)
```
server {
    listen	 80;
    server_name  momyeon.site;
    return 301 https://www.momyeon.site$request_uri;
}

server {
    listen	 443 ssl;
    server_name  momyeon.site;

    ssl_certificate /root/ssl/nginx-ssl.crt;
    ssl_certificate_key /root/ssl/nginx-ssl.key;

    location / {
        proxy_pass https://localhost:3000;
    }
}
```
2) restart

## 실행
1) `yarn install`
2) `pm2 --name 'front-server-https' start yarn -- run https`