### PR TITLE
docker-compose 환경변수 수정, redis 설정

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -11,22 +11,35 @@ services:
       - common-net
     depends_on:
       - mysql
+      - redis
 
   mysql:
     container_name: mysql-host
     image: mysql:8.0
-    env_file:
-      - ./src/config/.env.production
+    restart: always
     ports:
       - 3307:3306
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PW}
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+    networks:
+      - common-net
+
+  redis:
+    container_name: redis-host
+    image: redis:7.0
+    ports:
+      - 6379:6379
+    restart: always
+    env_file:
+      - ./src/config/.env.production
+    command: redis-server /usr/local/conf/redis.conf --requirepass ${REDIS_PW}
     volumes:
-      - ./init.sql:/data/application/init.sql
-    command: --init-file /data/application/init.sql
+      - ./src/config/redis.conf:/usr/local/conf/redis.conf
     networks:
       - common-net
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@liaoliaots/nestjs-redis": "^9.0.4",
     "@nestjs/axios": "^1.0.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.2.0",
@@ -33,6 +34,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "cookie-parser": "^1.4.6",
+    "ioredis": "^5.2.4",
     "mysql2": "^2.3.3",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,8 @@ import { AuthModule } from './auth/auth.module';
 
 import { AppLoggerMiddleware } from './middlewares/appLoger.middleware';
 import { QuestionModule } from './question/question.module';
+import { RedisModule } from '@liaoliaots/nestjs-redis';
+import { FeedbackModule } from './feedback/feedback.module';
 
 const env = process.env.NODE_ENV;
 
@@ -34,16 +36,24 @@ const env = process.env.NODE_ENV;
       }),
       inject: [ConfigService],
     }),
+    RedisModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (config: ConfigService) => ({
+        config: {
+          host: config.get('REDIS_HOST'),
+          port: config.get('REDIS_PORT'),
+          password: config.get('REDIS_PW'),
+        },
+      }),
+      inject: [ConfigService],
+    }),
 
     InterviewModule,
-
     CategoryModule,
-
     UserModule,
-
     AuthModule,
-
     QuestionModule,
+    FeedbackModule,
   ],
   controllers: [],
   providers: [],

--- a/backend/src/config/redis.conf
+++ b/backend/src/config/redis.conf
@@ -1,0 +1,1 @@
+maxclients 1000

--- a/backend/src/feedback/feedback.controller.ts
+++ b/backend/src/feedback/feedback.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { FeedbackService } from './feedback.service';
+
+@Controller({ version: '1', path: 'feedback' })
+export class FeedbackController {
+  constructor(private readonly feedbackService: FeedbackService) {}
+
+  @Get()
+  test() {
+    return this.feedbackService.test();
+  }
+}

--- a/backend/src/feedback/feedback.module.ts
+++ b/backend/src/feedback/feedback.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { FeedbackController } from './feedback.controller';
+import { FeedbackService } from './feedback.service';
+
+@Module({
+  controllers: [FeedbackController],
+  providers: [FeedbackService],
+})
+export class FeedbackModule {}

--- a/backend/src/feedback/feedback.service.ts
+++ b/backend/src/feedback/feedback.service.ts
@@ -1,0 +1,13 @@
+import { InjectRedis } from '@liaoliaots/nestjs-redis';
+import { Injectable } from '@nestjs/common';
+import Redis from 'ioredis';
+
+@Injectable()
+export class FeedbackService {
+  constructor(@InjectRedis() private readonly redis: Redis) {}
+
+  async test() {
+    await this.redis.set('key3', 'value3');
+    return await this.redis.get('key3');
+  }
+}

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -392,6 +392,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@ioredis/commands@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
+  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -656,6 +661,13 @@
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@liaoliaots/nestjs-redis@^9.0.4":
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/@liaoliaots/nestjs-redis/-/nestjs-redis-9.0.4.tgz#ce2dc4dfbb52f09c2962d6f593abe747e4d173c3"
+  integrity sha512-iVktrMEcnzCmi805CSNGcxMyQc02E2L2KTYPiSObIaJJ9Zq4Eqtc6dK8+tqDP7yL2A6qj6xgVagvZbXVsb7i2A==
+  dependencies:
+    tslib "2.4.1"
 
 "@nestjs/axios@^1.0.0":
   version "1.0.0"
@@ -1803,6 +1815,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
+cluster-key-slot@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2864,6 +2881,21 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
+ioredis@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.2.4.tgz#9e262a668bc29bae98f2054c1e0d7efd86996b96"
+  integrity sha512-qIpuAEt32lZJQ0XyrloCRdlEdUUNGG9i0UOk6zgzK6igyudNWqEBxfH6OlbnOOoBBvr1WB02mm8fR55CnikRng==
+  dependencies:
+    "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.0.1"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -3518,10 +3550,20 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
   integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
@@ -4203,6 +4245,18 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
+  dependencies:
+    redis-errors "^1.0.0"
+
 reflect-metadata@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
@@ -4492,6 +4546,11 @@ stack-utils@^2.0.3:
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 statuses@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
관련 이슈: #73 

# 완료 작업
- docker-compose 에 redis 추가하기
- nest와 redis 연결하기

# 설명
- docker-compose 명령어의 --env-file 옵션과 docker-compose.yml 파일 안에서의 env_file 설정은 다르게 동작한다.
  - 전자는 호스트의 환경변수를 docker-compose.yml 파일안에서 적용할때 쓰인다. 
  - 후자는 호스트에서 env파일을 읽어 컨테이너 안에서 command 사용 시 환경변수를 사용할때 쓰인다. (컨테이너 안의 환경변수로 적용된다.)
- 지금까지 쓰던 DB_PW는 호스트의 환경변수였고(의도한게 아니었습니다), 이제는--env-file 옵션을 줘서 .env.production에서 의DB_PW를 사용할 수 있다.

### 예시
* 실행 커맨드 : docker-compose up --env-file ./src/config/.env.production --build -d
```yml
mysql:
    # 생략...
    environment:
      MYSQL_ROOT_PASSWORD: ${DB_PW}  #  여기서 쓰이는 DB_PW는 --env-file 옵션으로 인해 사용가능하다. 

redis:
    #  생략...
    env_file:
      - ./src/config/.env.production
    command: redis-server /usr/local/conf/redis.conf --requirepass ${REDIS_PW}  # 여기서 쓰이는 REDIS_PW는 바로 위의  env_file로 설정했기 때문에 사용가능하다.
```

## 이후 해야할 일
- redis 설정
  - 최대 클라이언트 수, 저장방식, 클러스터 등.. 필요에 따라 적용할게 많다.
  - http://redisgate.kr/redis/server/redis_conf_han.php
- 피드백 api 작성