### PR TITLE
Fix: 사용자 인증이 필요한 api 요청엔 credential을 보내야 함 

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -22,6 +22,8 @@ if (process.env.NEXT_PUBLIC_TEMP === "true") {
   });
 }
 
+axios.defaults.withCredentials = true;
+
 export default function App({ Component, pageProps }: AppProps) {
   const [queryClient] = useState(() => new QueryClient());
 


### PR DESCRIPTION
글이 안 써지거나, 개인화 된 정보를 인증하지 식별하지 못하는 문제가 있었다.
axios default를 쿠키를 항상 전송하는 것으로 변경했다.
