### PR TITLE
fix: #102 글쓰기 페이지 복구

### DIFF
--- a/frontend/utils/hooks/useCategoryQuery.ts
+++ b/frontend/utils/hooks/useCategoryQuery.ts
@@ -3,7 +3,7 @@ import getAllCategory from "utils/api/getAllCategory";
 
 const useCategoryQuery = () => {
   const { data } = useQuery(["categories"], () => getAllCategory());
-  return data?.data.category;
+  return data;
 };
 
 export { useCategoryQuery };


### PR DESCRIPTION
배경: 
axios 요청을 util에 따로 분리

원인: 
getAllCategories가 data?.data.category를 반환
getAllCateogries를 리액트 쿼리로 감싸는 useCategoryQuery도 data?.data.category를 반환했음.
data?.data.category.data.category를 반환한 것
