### PR TITLE
피드백 저장, 조회 api 구현

### DIFF
--- a/backend/src/config/redis.conf
+++ b/backend/src/config/redis.conf
@@ -1,1 +1,1 @@
-maxclients 1000
+

--- a/backend/src/entities/feedback.entity.ts
+++ b/backend/src/entities/feedback.entity.ts
@@ -25,6 +25,15 @@ export class Feedback extends BaseEntity {
   @Column({ type: 'text' })
   content: string;
 
+  @Column()
+  interviewId: number;
+
+  @Column()
+  user_from: number;
+
+  @Column()
+  user_to: number;
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/backend/src/entities/feedback.entity.ts
+++ b/backend/src/entities/feedback.entity.ts
@@ -25,6 +25,9 @@ export class Feedback extends BaseEntity {
   @Column({ type: 'text' })
   content: string;
 
+  @Column({ type: 'text' })
+  questionContent: string;
+
   @Column()
   interviewId: number;
 
@@ -33,6 +36,12 @@ export class Feedback extends BaseEntity {
 
   @Column()
   user_to: number;
+
+  @Column()
+  user_fromName: string;
+
+  @Column()
+  user_toName: string;
 
   @CreateDateColumn()
   created_at: Date;

--- a/backend/src/feedback/dto/save-feedback.dto.ts
+++ b/backend/src/feedback/dto/save-feedback.dto.ts
@@ -1,0 +1,7 @@
+export interface SaveFeedbackDto {
+  userId: number;
+  nickname: string;
+  type: number;
+  questionId: number;
+  feedback: string;
+}

--- a/backend/src/feedback/feedback.controller.ts
+++ b/backend/src/feedback/feedback.controller.ts
@@ -16,16 +16,17 @@ export class FeedbackController {
     @Body() saveFeedbackDto: SaveFeedbackDto,
     @UserData() userData: UserInfo,
   ) {
-    try {
-      const result = await this.feedbackService.saveFeedback(
-        +interviewId,
-        saveFeedbackDto,
-        userData,
-      );
-      return { message: result ? 'success' : 'failed' };
-    } catch (err) {
-      console.error(err);
-      throw err;
-    }
+    await this.feedbackService.saveFeedback(
+      +interviewId,
+      saveFeedbackDto,
+      userData,
+    );
+    return { message: 'success' };
+  }
+
+  @Get(':interviewId')
+  @UseGuards(JwtGuard)
+  getAllFeedbacks(@Param('interviewId') interviewId: string) {
+    return this.feedbackService.getAllFeedbacks(interviewId);
   }
 }

--- a/backend/src/feedback/feedback.controller.ts
+++ b/backend/src/feedback/feedback.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Patch, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { JwtGuard } from 'src/guards/jwtAuth.guard';
 import { UserInfo } from 'src/interfaces/user.interface';
 import { UserData } from 'src/user/user.decorator';
@@ -21,6 +29,12 @@ export class FeedbackController {
       saveFeedbackDto,
       userData,
     );
+    return { message: 'success' };
+  }
+
+  @Post(':interviewId')
+  async saveAllFeedback(@Param('interviewId') interviewId: string) {
+    await this.feedbackService.saveAllFeedback(+interviewId);
     return { message: 'success' };
   }
 

--- a/backend/src/feedback/feedback.controller.ts
+++ b/backend/src/feedback/feedback.controller.ts
@@ -32,15 +32,16 @@ export class FeedbackController {
     return { message: 'success' };
   }
 
+  // TODO: 요청자가 해당 면접의 호스트인지 판별, 호스트가 아닐 시 오류
   @Post(':interviewId')
   async saveAllFeedback(@Param('interviewId') interviewId: string) {
     await this.feedbackService.saveAllFeedback(+interviewId);
     return { message: 'success' };
   }
 
-  // @Get(':interviewId')
-  // @UseGuards(JwtGuard)
-  // getAllFeedbacks(@Param('interviewId') interviewId: string) {
-  //   return this.feedbackService.getAllFeedbacks(interviewId);
-  // }
+  // TODO: 요청자가 해당 면접의 참가자인지 판별
+  @Get(':interviewId')
+  getAllFeedbacks(@Param('interviewId') interviewId: string) {
+    return this.feedbackService.getAllFeedbacks(+interviewId);
+  }
 }

--- a/backend/src/feedback/feedback.controller.ts
+++ b/backend/src/feedback/feedback.controller.ts
@@ -24,9 +24,9 @@ export class FeedbackController {
     return { message: 'success' };
   }
 
-  @Get(':interviewId')
-  @UseGuards(JwtGuard)
-  getAllFeedbacks(@Param('interviewId') interviewId: string) {
-    return this.feedbackService.getAllFeedbacks(interviewId);
-  }
+  // @Get(':interviewId')
+  // @UseGuards(JwtGuard)
+  // getAllFeedbacks(@Param('interviewId') interviewId: string) {
+  //   return this.feedbackService.getAllFeedbacks(interviewId);
+  // }
 }

--- a/backend/src/feedback/feedback.controller.ts
+++ b/backend/src/feedback/feedback.controller.ts
@@ -1,12 +1,31 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, UseGuards } from '@nestjs/common';
+import { JwtGuard } from 'src/guards/jwtAuth.guard';
+import { UserInfo } from 'src/interfaces/user.interface';
+import { UserData } from 'src/user/user.decorator';
+import { SaveFeedbackDto } from './dto/save-feedback.dto';
 import { FeedbackService } from './feedback.service';
 
 @Controller({ version: '1', path: 'feedback' })
 export class FeedbackController {
   constructor(private readonly feedbackService: FeedbackService) {}
 
-  @Get()
-  test() {
-    return this.feedbackService.test();
+  @Patch(':interviewId')
+  @UseGuards(JwtGuard)
+  async saveFeedback(
+    @Param('interviewId') interviewId: string,
+    @Body() saveFeedbackDto: SaveFeedbackDto,
+    @UserData() userData: UserInfo,
+  ) {
+    try {
+      const result = await this.feedbackService.saveFeedback(
+        +interviewId,
+        saveFeedbackDto,
+        userData,
+      );
+      return { message: result ? 'success' : 'failed' };
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
   }
 }

--- a/backend/src/feedback/feedback.module.ts
+++ b/backend/src/feedback/feedback.module.ts
@@ -2,12 +2,24 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from 'src/auth/auth.module';
 import { Feedback } from 'src/entities/feedback.entity';
+import { InterviewQuestion } from 'src/entities/interviewQuestion.entity';
+import { SimpleQuestion } from 'src/entities/simpleQuestion.entity';
 import { User } from 'src/entities/user.entity';
+import { UserQuestion } from 'src/entities/userQuestion.entity';
 import { FeedbackController } from './feedback.controller';
 import { FeedbackService } from './feedback.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Feedback]), AuthModule],
+  imports: [
+    TypeOrmModule.forFeature([
+      User,
+      Feedback,
+      UserQuestion,
+      InterviewQuestion,
+      SimpleQuestion,
+    ]),
+    AuthModule,
+  ],
   controllers: [FeedbackController],
   providers: [FeedbackService],
 })

--- a/backend/src/feedback/feedback.module.ts
+++ b/backend/src/feedback/feedback.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from 'src/auth/auth.module';
+import { User } from 'src/entities/user.entity';
 import { FeedbackController } from './feedback.controller';
 import { FeedbackService } from './feedback.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([User]), AuthModule],
   controllers: [FeedbackController],
   providers: [FeedbackService],
 })

--- a/backend/src/feedback/feedback.module.ts
+++ b/backend/src/feedback/feedback.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from 'src/auth/auth.module';
+import { Feedback } from 'src/entities/feedback.entity';
 import { User } from 'src/entities/user.entity';
 import { FeedbackController } from './feedback.controller';
 import { FeedbackService } from './feedback.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), AuthModule],
+  imports: [TypeOrmModule.forFeature([User, Feedback]), AuthModule],
   controllers: [FeedbackController],
   providers: [FeedbackService],
 })

--- a/backend/src/feedback/feedback.service.ts
+++ b/backend/src/feedback/feedback.service.ts
@@ -1,13 +1,41 @@
 import { InjectRedis } from '@liaoliaots/nestjs-redis';
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import Redis from 'ioredis';
+import { UserInfo } from 'src/interfaces/user.interface';
+import { SaveFeedbackDto } from './dto/save-feedback.dto';
 
 @Injectable()
 export class FeedbackService {
   constructor(@InjectRedis() private readonly redis: Redis) {}
 
-  async test() {
-    await this.redis.set('key3', 'value3');
-    return await this.redis.get('key3');
+  async saveFeedback(
+    interviewId: number,
+    saveFeedbackDto: SaveFeedbackDto,
+    userData: UserInfo,
+  ): Promise<boolean> {
+    try {
+      const { id: fromId, nickname: fromName } = userData;
+      const {
+        userId: toId,
+        nickname: toName,
+        type,
+        questionId,
+        feedback,
+      } = saveFeedbackDto;
+
+      const result = await this.redis.set(
+        `question:${interviewId}:${fromId}:${toId}:${type}:${questionId}`,
+        JSON.stringify({
+          interviewer: fromName,
+          interviewee: toName,
+          content: feedback,
+        }),
+      );
+
+      return result === 'OK';
+    } catch (err) {
+      console.error(err);
+      throw new InternalServerErrorException('피드백 저장 오류');
+    }
   }
 }

--- a/backend/src/feedback/feedback.service.ts
+++ b/backend/src/feedback/feedback.service.ts
@@ -3,6 +3,11 @@ import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import Redis from 'ioredis';
 import { Feedback } from 'src/entities/feedback.entity';
+import { InterviewQuestion } from 'src/entities/interviewQuestion.entity';
+import { SimpleQuestion } from 'src/entities/simpleQuestion.entity';
+import { UserQuestion } from 'src/entities/userQuestion.entity';
+import { QuestionType } from 'src/enum/questionType.enum';
+import { FeedbackInfo } from 'src/interfaces/feedback.interface';
 import { UserInfo } from 'src/interfaces/user.interface';
 import { Repository } from 'typeorm';
 import { SaveFeedbackDto } from './dto/save-feedback.dto';
@@ -11,9 +16,28 @@ import { SaveFeedbackDto } from './dto/save-feedback.dto';
 export class FeedbackService {
   constructor(
     @InjectRedis() private readonly redis: Redis,
+    @InjectRepository(UserQuestion)
+    private readonly userQuestionRepository: Repository<UserQuestion>,
+    @InjectRepository(InterviewQuestion)
+    private readonly interviewQuestionRepository: Repository<InterviewQuestion>,
+    @InjectRepository(SimpleQuestion)
+    private readonly simpleQuestionRepository: Repository<SimpleQuestion>,
     @InjectRepository(Feedback)
     private readonly feedbackRepository: Repository<Feedback>,
   ) {}
+
+  selectQuestionRepository(type: QuestionType) {
+    switch (type) {
+      case QuestionType.INTERVIEW:
+        return this.interviewQuestionRepository;
+      case QuestionType.SIMPLE:
+        return this.simpleQuestionRepository;
+      case QuestionType.USER:
+        return this.userQuestionRepository;
+      default:
+        throw new InternalServerErrorException('잘못된 DB 접근');
+    }
+  }
 
   async saveFeedback(
     interviewId: number,
@@ -30,10 +54,19 @@ export class FeedbackService {
         feedback,
       } = saveFeedbackDto;
 
+      const [question] = await this.selectQuestionRepository(type).findBy({
+        id: questionId,
+      });
+
       const result: number = await this.redis.hset(
         `question:${interviewId}`,
         `${fromId}:${toId}:${type}:${questionId}`,
-        feedback,
+        JSON.stringify({
+          fromName,
+          toName,
+          feedback,
+          questionContent: question.content,
+        }),
       );
 
       return result;
@@ -49,17 +82,23 @@ export class FeedbackService {
 
       const feedbacks = Object.entries(result).map(([key, value]) => {
         const [fromId, toId, type, questionId] = key.split(':').map((n) => +n);
+        const { fromName, toName, feedback, questionContent } =
+          JSON.parse(value);
 
         return this.feedbackRepository.create({
           interviewId,
           question_type: type,
           question_id: questionId,
-          content: value,
+          content: feedback,
           user_from: fromId,
           user_to: toId,
+          user_fromName: fromName,
+          user_toName: toName,
+          questionContent,
         });
       });
       await this.feedbackRepository.save(feedbacks);
+
       return feedbacks.length;
     } catch (err) {
       console.error(err);
@@ -67,5 +106,46 @@ export class FeedbackService {
     }
   }
 
-  // async getAllFeedbacks(interviewId: string) {}
+  async getAllFeedbacks(interviewId: number) {
+    const feedbacks = await this.feedbackRepository.findBy({
+      interviewId,
+    });
+
+    const result = feedbacks.reduce((acc: any, cur: any) => {
+      const {
+        question_type,
+        question_id,
+        user_to,
+        user_fromName,
+        user_toName,
+        content,
+        questionContent,
+      } = cur;
+
+      const found = acc.find((userTo) => userTo.userId === user_to);
+
+      const feedbackInfo: FeedbackInfo = {
+        nickname: user_fromName,
+        type: question_type,
+        id: question_id,
+        contents: questionContent,
+        feedback: content,
+        isScrapped: false, // TODO: 스크랩 여부
+      };
+
+      if (!found) {
+        acc.push({
+          userId: user_to,
+          userName: user_toName,
+          question: [feedbackInfo],
+        });
+        return acc;
+      }
+
+      found.question.push(feedbackInfo);
+      return acc;
+    }, []);
+
+    return { feedbacks: result };
+  }
 }

--- a/backend/src/feedback/feedback.service.ts
+++ b/backend/src/feedback/feedback.service.ts
@@ -1,12 +1,19 @@
 import { InjectRedis } from '@liaoliaots/nestjs-redis';
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import Redis from 'ioredis';
+import { Feedback } from 'src/entities/feedback.entity';
 import { UserInfo } from 'src/interfaces/user.interface';
+import { Repository } from 'typeorm';
 import { SaveFeedbackDto } from './dto/save-feedback.dto';
 
 @Injectable()
 export class FeedbackService {
-  constructor(@InjectRedis() private readonly redis: Redis) {}
+  constructor(
+    @InjectRedis() private readonly redis: Redis,
+    @InjectRepository(Feedback)
+    private readonly feedbackRepository: Repository<Feedback>,
+  ) {}
 
   async saveFeedback(
     interviewId: number,
@@ -26,21 +33,39 @@ export class FeedbackService {
       const result: number = await this.redis.hset(
         `question:${interviewId}`,
         `${fromId}:${toId}:${type}:${questionId}`,
-        JSON.stringify({
-          interviewer: fromName,
-          interviewee: toName,
-          content: feedback,
-        }),
+        feedback,
       );
 
       return result;
     } catch (err) {
       console.error(err);
-      throw new InternalServerErrorException('피드백 저장 오류');
+      throw new InternalServerErrorException('피드백 임시 저장 실패');
     }
   }
 
-  // async getAllFeedbacks(interviewId: string) {
-  //   this.redis.keys();
-  // }
+  async saveAllFeedback(interviewId: number) {
+    try {
+      const result = await this.redis.hgetall(`question:${interviewId}`);
+
+      const feedbacks = Object.entries(result).map(([key, value]) => {
+        const [fromId, toId, type, questionId] = key.split(':').map((n) => +n);
+
+        return this.feedbackRepository.create({
+          interviewId,
+          question_type: type,
+          question_id: questionId,
+          content: value,
+          user_from: fromId,
+          user_to: toId,
+        });
+      });
+      await this.feedbackRepository.save(feedbacks);
+      return feedbacks.length;
+    } catch (err) {
+      console.error(err);
+      throw new InternalServerErrorException('피드백 저장 실패');
+    }
+  }
+
+  // async getAllFeedbacks(interviewId: string) {}
 }

--- a/backend/src/feedback/feedback.service.ts
+++ b/backend/src/feedback/feedback.service.ts
@@ -12,7 +12,7 @@ export class FeedbackService {
     interviewId: number,
     saveFeedbackDto: SaveFeedbackDto,
     userData: UserInfo,
-  ): Promise<boolean> {
+  ): Promise<number> {
     try {
       const { id: fromId, nickname: fromName } = userData;
       const {
@@ -23,8 +23,9 @@ export class FeedbackService {
         feedback,
       } = saveFeedbackDto;
 
-      const result = await this.redis.set(
-        `question:${interviewId}:${fromId}:${toId}:${type}:${questionId}`,
+      const result: number = await this.redis.hset(
+        `question:${interviewId}`,
+        `${fromId}:${toId}:${type}:${questionId}`,
         JSON.stringify({
           interviewer: fromName,
           interviewee: toName,
@@ -32,16 +33,14 @@ export class FeedbackService {
         }),
       );
 
-      if (result !== 'OK') {
-        throw new InternalServerErrorException('피드백 저장 오류');
-      }
-
-      return true;
+      return result;
     } catch (err) {
       console.error(err);
       throw new InternalServerErrorException('피드백 저장 오류');
     }
   }
 
-  async getAllFeedbacks(interviewId: string) {}
+  // async getAllFeedbacks(interviewId: string) {
+  //   this.redis.keys();
+  // }
 }

--- a/backend/src/feedback/feedback.service.ts
+++ b/backend/src/feedback/feedback.service.ts
@@ -32,10 +32,16 @@ export class FeedbackService {
         }),
       );
 
-      return result === 'OK';
+      if (result !== 'OK') {
+        throw new InternalServerErrorException('피드백 저장 오류');
+      }
+
+      return true;
     } catch (err) {
       console.error(err);
       throw new InternalServerErrorException('피드백 저장 오류');
     }
   }
+
+  async getAllFeedbacks(interviewId: string) {}
 }

--- a/backend/src/interfaces/feedback.interface.ts
+++ b/backend/src/interfaces/feedback.interface.ts
@@ -1,0 +1,10 @@
+import { QuestionType } from 'src/enum/questionType.enum';
+
+export interface FeedbackInfo {
+  nickname: string;
+  type: QuestionType;
+  id: number;
+  contents: string;
+  feedback: string;
+  isScrapped: boolean;
+}


### PR DESCRIPTION
관련 이슈: #79 

# 작업 내용
- PATCH /feedback/:interviewId : redis에 피드백 임시저장 api
- POST /feedback/:interviewId : redis에 저장된 데이터를 mysql db에 저장
- GET /fefedback/:interviewId : db에서 종합 피드백정보를 조회해서 응답

# 설명
## redis의 HSET 사용
HSET 자료구조를 사용해 키-필드-값 형태로 피드백을 redis에 저장한다. 수정에 대해선 overwrite 되므로 지장이 없다.
```
키:  [question:인터뷰id] 
필드 : [피드백 준사람 id:받은사람 id:질문타입:질문id]
값 : { 
  fromName(피드백 보낸 유저 닉네임), 
  toName(피드백 받은 유저 닉네임), 
  feedback(피드백 내용), 
  questionContent(질문내용) 
} 
```
```
# 예시

HSET question:1 1:4:1:2 {"fromName":"SeungheonShin","toName":"테스터4","feedback":"피드백내용", "questionContent":"
문제내용"}
```
- 위의 명령은 아래의 코드와 같다.
```typescript
const result: number = await this.redis.hset(
        `question:${interviewId}`,
        `${fromId}:${toId}:${type}:${questionId}`,
        JSON.stringify({
          fromName,
          toName,
          feedback,
          questionContent: question.content,
        }),
      );
```
## redis의 피드백을 mysql에 저장
- redis의 HGETALL 명령어로 모든 피드백을 불러온다.
- 필드값을 파싱해서 유저 정보를 구분한다.

```typescript
      // HGETALL
      const result = await this.redis.hgetall(`question:${interviewId}`);

      const feedbacks = Object.entries(result).map(([key, value]) => {
        const [fromId, toId, type, questionId] = key.split(':').map((n) => +n);
        const { fromName, toName, feedback, questionContent } =
          JSON.parse(value);

        return this.feedbackRepository.create({
           // 피드백 내용
        });
      });
      await this.feedbackRepository.save(feedbacks);
```

## feedback 테이블 비정규화
- 기존 feedback 테이블에는 닉네임, 질문 내용이 없어 모두 join을 통해 조회해야 한다.
- 컬럼에 이 정보를 추가하고 join이 필요없도록 수정

```typescript
@Column({ type: 'text' })
questionContent: string;

@Column()
interviewId: number;

@Column()
user_from: number;

@Column()
user_to: number;

@Column()
user_fromName: string;

@Column()
user_toName: string;
```
