### PR TITLE
jwt verify과정에서 db 접근 부분 삭제, 모의면접 신청 api  (선착순 수락) 구현

### DIFF
--- a/backend/src/entities/interview.entity.ts
+++ b/backend/src/entities/interview.entity.ts
@@ -26,6 +26,9 @@ export class Interview extends BaseEntity {
   @Column()
   max_member: number;
 
+  @Column({ default: 0 })
+  current_member: number;
+
   @Column()
   contact: string;
 

--- a/backend/src/entities/userInterview.entity.ts
+++ b/backend/src/entities/userInterview.entity.ts
@@ -20,6 +20,12 @@ export class UserInterview extends BaseEntity {
   @Column()
   status: UserInterviewStatus;
 
+  @Column()
+  userId: number;
+
+  @Column()
+  interviewId: number;
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/backend/src/interfaces/user.interface.ts
+++ b/backend/src/interfaces/user.interface.ts
@@ -1,7 +1,3 @@
-export interface UserPayload {
-  oauth_provider: string;
-  oauth_uid: string;
-}
 export interface UserInfo {
   oauth_provider: string;
   oauth_uid: string;

--- a/backend/src/interview/interview.controller.ts
+++ b/backend/src/interview/interview.controller.ts
@@ -87,4 +87,14 @@ export class InterviewController {
   remove(@Param('id') id: string, @UserData() userData: UserInfo) {
     return this.interviewService.remove(+id, userData.id);
   }
+
+  @Post('apply/:interviewId')
+  @UseGuards(JwtGuard)
+  async applyInterview(
+    @Param('interviewId') interviewId: string,
+    @UserData() userData: UserInfo,
+  ) {
+    await this.interviewService.applyInterview(+interviewId, userData);
+    return { message: 'success' };
+  }
 }

--- a/backend/src/question/question.controller.ts
+++ b/backend/src/question/question.controller.ts
@@ -14,7 +14,7 @@ import { UpdateQuestionDto } from './dto/update-question.dto';
 import { CreateUserQuestionDto } from './dto/create-user-question.dto';
 import { JwtGuard } from 'src/guards/jwtAuth.guard';
 import { UserData } from 'src/user/user.decorator';
-import { UserInfo, UserPayload } from 'src/interfaces/user.interface';
+import { UserInfo } from 'src/interfaces/user.interface';
 
 @Controller({ version: '1', path: 'question' })
 export class QuestionController {


### PR DESCRIPTION
관련 이슈: #112 

# 작업 내용
- jwt verify과정에서 db 접근 부분 삭제
- 모의면접 신청 api  (선착순 수락) 구현

# 설명
 ## jwt guard의 db접근 부분 삭제
- jwt guard에서 받는 토큰의 값은 두가지 형태이다.
  - 기간이 만료되거나 올바르지 않은 값
  - 위의 상황이 아닌 값, 즉 인증이 유효한 값
- 따라서 verifyToken 메소드가 정상적으로 수행되었다면 유효한 값이므로 추가적인 db 접근, 유저정보 비교의 과정이 필요없다.

## 모의면접 신청 api 선착순 구현
- 기존의 interview 엔티티에 current_member 컬럼을 추가하여 현재 인원을 파악하기 위한 추가적인 쿼리요청을 하지 않아도 되도록 했다.
- 선착순이므로 user_interview 테이블에서는 status의 값이 2(수락)로 저장되며, interview 테이블에서는 현재 멤버가 1 증가한다.
```typescript
await this.userInterviewRepository.save(userInterview);
await this.interviewRepository.update(interviewId, {
      current_member: current_member + 1,
});
```