### PR TITLE
refresh 토큰 로직 구현

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -13,11 +13,14 @@ import { User } from 'src/entities/user.entity';
 import { Repository } from 'typeorm';
 import { GithubLoginDto } from './dto/github-login.dto';
 import { UserInfo } from '../interfaces/user.interface';
+import { InjectRedis } from '@liaoliaots/nestjs-redis';
+import Redis from 'ioredis';
 
 @Injectable()
 export class AuthService {
   constructor(
     @InjectRepository(User) private readonly userRepository: Repository<User>,
+    @InjectRedis() private readonly redis: Redis,
     private readonly jwtService: JwtService,
     private readonly httpService: HttpService,
     private readonly configService: ConfigService,
@@ -60,7 +63,7 @@ export class AuthService {
       const accessToken = this.signAccessToken(userInfo);
       const refreshToken = this.signRefreshToken();
 
-      // TODO: refreshToken을 User 테이블에 저장
+      await this.redis.set(`refresh:${userId}`, refreshToken);
 
       return { accessToken, refreshToken };
     } catch (err) {

--- a/backend/src/guards/jwtAuth.guard.ts
+++ b/backend/src/guards/jwtAuth.guard.ts
@@ -1,3 +1,4 @@
+import { InjectRedis } from '@liaoliaots/nestjs-redis';
 import {
   CanActivate,
   ExecutionContext,
@@ -6,20 +7,49 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { Request, Response } from 'express';
+import Redis from 'ioredis';
 import { UserInfo } from '../interfaces/user.interface';
+
+interface DecodedUserInfo extends UserInfo {
+  iat: number;
+  exp: number;
+}
+interface VerifiedResult {
+  userInfo: UserInfo;
+  refreshed: boolean;
+}
 
 @Injectable()
 export class JwtGuard implements CanActivate {
-  constructor(private readonly jwtService: JwtService) {}
+  constructor(
+    @InjectRedis() private readonly redis: Redis,
+    private readonly jwtService: JwtService,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     try {
-      const request = context.switchToHttp().getRequest();
-      const token = request.cookies?.['accessToken'];
-      if (!token) throw new UnauthorizedException('토큰 정보 없음');
+      const request: Request = context.switchToHttp().getRequest();
+      const response: Response = context.switchToHttp().getResponse();
+      const accessToken = request.cookies?.['accessToken'];
+      const refreshToken = request.cookies?.['refreshToken'];
+      if (!accessToken) throw new UnauthorizedException('토큰 정보 없음');
 
-      const userInfo = this.verifyToken(token);
-      request.user = userInfo;
+      const { userInfo, refreshed }: VerifiedResult = await this.verifyToken(
+        accessToken,
+        refreshToken,
+      );
+
+      if (refreshed) {
+        const newAccessToken = this.signAccessToken(userInfo);
+        response.cookie('accessToken', newAccessToken, {
+          httpOnly: true,
+          secure: true,
+          sameSite: 'none',
+          maxAge: 24 * 60 * 60 * 1000,
+        });
+      }
+      request['user'] = userInfo;
 
       return true;
     } catch (err) {
@@ -28,25 +58,52 @@ export class JwtGuard implements CanActivate {
     }
   }
 
-  verifyToken(token: string): UserInfo {
+  async verifyToken(
+    accessToken: string,
+    refreshToken: string,
+  ): Promise<VerifiedResult> {
     try {
-      const verified = this.jwtService.verify(token);
-      return verified;
+      const userInfo = this.jwtService.verify(accessToken) as DecodedUserInfo;
+      return { userInfo, refreshed: false };
     } catch (err) {
-      console.error(err);
-      switch (err.message) {
-        case 'INVALID_TOKEN':
-        case 'TOKEN_IS_ARRAY':
-        case 'NO_USER':
+      switch (err.name) {
+        case 'JsonWebTokenError':
           throw new UnauthorizedException('유효하지 않은 토큰');
 
-        case 'EXPIRED_TOKEN':
-          // TODO: refresh token으로 재발급
-          throw new UnauthorizedException('토큰 기간 만료');
+        case 'TokenExpiredError':
+          try {
+            console.log('access token expired!');
+            const { id, profile, nickname, oauth_provider, oauth_uid } =
+              this.jwtService.decode(accessToken) as DecodedUserInfo;
+            const userInfo: UserInfo = {
+              id,
+              profile,
+              nickname,
+              oauth_provider,
+              oauth_uid,
+            };
+            const savedRefreshToken = await this.redis.get(`refresh:${id}`);
+
+            if (savedRefreshToken === refreshToken) {
+              console.log('refresh found!! id:', id);
+              return { userInfo, refreshed: true };
+            }
+            throw new UnauthorizedException('유저 정보 불일치');
+          } catch (err) {
+            console.error(err);
+            throw new UnauthorizedException('유효하지 않은 토큰');
+          }
 
         default:
           throw new InternalServerErrorException('서버 내부 오류');
       }
     }
+  }
+
+  signAccessToken(paylod: UserInfo) {
+    return this.jwtService.sign(paylod, {
+      algorithm: 'HS256',
+      expiresIn: '1h',
+    });
   }
 }


### PR DESCRIPTION
관련 이슈: #124 

# 작업 내용
- 회원가입 또는 로그인 시 redis에 refresh토큰 저장
- refresh 토큰 로직 구현

# 설명
- refreshToken은 db에도 저장할 수 있으나 accessToken이 만료된 사용자의 모든 인증요청에 대해 접근해야 하므로 비용을 줄이기 위해 redis에 저장
- jwt Auth에서 인증 확인 시 accessToken이 만료되었다면 decode 해서 유저의 정보 파악
  - 유저의 id로 redis에서 refreshToken 검색
  - 만약 refreshToken값이 요청 쿠키의 refreshToken값과 일치한다면 동일한 사용자이므로 새로운 accessToken 발행
    - 이 때 refreshToken은 갱신하지 않는다.
  - 만약 refreshToken도 만료되었거나, 사용자가 일치하지 않는다면 401 에러 발생
