### PR TITLE
feat: 종합질문 생성 로직 수정#179

### DIFF
--- a/backend/src/question/question.service.ts
+++ b/backend/src/question/question.service.ts
@@ -183,9 +183,8 @@ export class QuestionService {
     const userInterviewQuestion =
       await this.InterviewQuestionRepository.createQueryBuilder()
         .select(['user_to AS userTo', 'userId', 'id', 'content'])
-        .where('interviewId = :interviewId AND userId = :userId', {
+        .where('interviewId = :interviewId', {
           interviewId: interviewId,
-          userId: userData.id,
         })
         .getRawMany();
     interviewUser.forEach((userElement) => {
@@ -201,7 +200,7 @@ export class QuestionService {
         }
       });
       simpleQuestionData.forEach((simpleElement) => {
-        if (temp.length < 15) {
+        if (temp.length < 20) {
           temp.push({
             type: QuestionType.SIMPLE,
             id: simpleElement.id,
@@ -393,6 +392,7 @@ export class InterviewQuestionService {
           temp.push({
             id: questionElement.id,
             content: questionElement.content,
+            feedback: '',
           });
         }
       });
@@ -400,7 +400,6 @@ export class InterviewQuestionService {
         userId: userElement.userId,
         userName: userElement.userName,
         question: temp,
-        feedback: '',
       });
     });
     return userInterviewQuestionData;


### PR DESCRIPTION
#179 

질문을 가져오는 대상을 본인에서 전체로 수정(전체를 가져 오는데, 사람 별 최대 질문 개수에 대한 논의 필요)
심플질문 출력은 최대 20개로 증가(질문 추가는 지속적으로 필요)
