### PR TITLE
모의면접 신청 시 마감여부 확인 로직 추가

### DIFF
--- a/backend/src/entities/interview.entity.ts
+++ b/backend/src/entities/interview.entity.ts
@@ -1,3 +1,4 @@
+import { InterviewStatus } from 'src/enum/userInterviewStatus.enum';
 import {
   BaseEntity,
   Column,
@@ -42,8 +43,8 @@ export class Interview extends BaseEntity {
   @Column({ default: 0 })
   count: number;
 
-  @Column({ default: 0 })
-  status: number;
+  @Column({ default: InterviewStatus.RECRUITING })
+  status: InterviewStatus;
 
   @CreateDateColumn()
   created_at: Date;

--- a/backend/src/enum/userInterviewStatus.enum.ts
+++ b/backend/src/enum/userInterviewStatus.enum.ts
@@ -4,3 +4,8 @@ export enum UserInterviewStatus {
   ACCEPTED,
   REJECTED,
 }
+
+export enum InterviewStatus {
+  RECRUITING = 0,
+  ENDED,
+}

--- a/backend/src/feedback/feedback.service.ts
+++ b/backend/src/feedback/feedback.service.ts
@@ -99,6 +99,8 @@ export class FeedbackService {
       });
       await this.feedbackRepository.save(feedbacks);
 
+      await this.redis.del(`question:${interviewId}`);
+
       return feedbacks.length;
     } catch (err) {
       console.error(err);

--- a/backend/src/guards/interview.guard.ts
+++ b/backend/src/guards/interview.guard.ts
@@ -1,0 +1,35 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Request } from 'express';
+import { Interview } from 'src/entities/interview.entity';
+import { InterviewStatus } from 'src/enum/userInterviewStatus.enum';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class InterviewGuard implements CanActivate {
+  constructor(
+    @InjectRepository(Interview)
+    private readonly interviewRepository: Repository<Interview>,
+  ) {}
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request: Request = context.switchToHttp().getRequest();
+    const interviewId: number = +request.params.interviewId;
+    const [interview] = await this.interviewRepository.findBy({
+      id: interviewId,
+    });
+
+    if (!interview) throw new NotFoundException('면접 정보 없음');
+
+    const interviewStatus: InterviewStatus = interview.status;
+    if (interviewStatus === InterviewStatus.ENDED) {
+      throw new ForbiddenException('이미 마감된 모의면접입니다.');
+    }
+    return true;
+  }
+}

--- a/backend/src/interview/interview.controller.ts
+++ b/backend/src/interview/interview.controller.ts
@@ -21,7 +21,7 @@ import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from 'src/entities/user.entity';
 import { Repository } from 'typeorm';
-import { UserInterviewStatus } from 'src/enum/userInterviewStatus.enum';
+import { InterviewGuard } from 'src/guards/interview.guard';
 
 @Controller({ version: '1', path: 'interview' })
 export class InterviewController {
@@ -93,7 +93,7 @@ export class InterviewController {
   }
 
   @Post('apply/:interviewId')
-  @UseGuards(JwtGuard)
+  @UseGuards(JwtGuard, InterviewGuard)
   async applyInterview(
     @Param('interviewId') interviewId: string,
     @UserData() userData: UserInfo,

--- a/backend/src/interview/interview.service.ts
+++ b/backend/src/interview/interview.service.ts
@@ -392,6 +392,12 @@ export class InterviewService {
         throw new ForbiddenException('면접 인원 정원 초과');
       }
 
+      const [exRecord] = await this.userInterviewRepository.findBy({
+        userId,
+        interviewId,
+      });
+      if (exRecord) throw new ForbiddenException('이미 신청했습니다.');
+
       const userInterview = this.userInterviewRepository.create({
         userId,
         interviewId,

--- a/backend/src/interview/interview.service.ts
+++ b/backend/src/interview/interview.service.ts
@@ -17,7 +17,10 @@ import { SelectInterviewDto } from './dto/select-interview.dto';
 import { User } from 'src/entities/user.entity';
 import { Resume } from 'src/entities/resume.entity';
 import { Item } from 'src/entities/item.entity';
-import { UserInterviewStatus } from 'src/enum/userInterviewStatus.enum';
+import {
+  InterviewStatus,
+  UserInterviewStatus,
+} from 'src/enum/userInterviewStatus.enum';
 import { UserInfo } from 'src/interfaces/user.interface';
 
 @Injectable()
@@ -396,8 +399,13 @@ export class InterviewService {
       });
 
       await this.userInterviewRepository.save(userInterview);
+
       await this.interviewRepository.update(interviewId, {
         current_member: current_member + 1,
+        status:
+          current_member + 1 === max_member
+            ? InterviewStatus.ENDED
+            : InterviewStatus.RECRUITING,
       });
 
       return true;

--- a/backend/src/question/question.controller.ts
+++ b/backend/src/question/question.controller.ts
@@ -37,9 +37,12 @@ export class QuestionController {
   }
 
   @UseGuards(JwtGuard)
-  @Get(':id')
-  findOne(@Param('id') id: string, @UserData() userData: UserInfo) {
-    return this.questionService.findRoomQuestion(+id, userData);
+  @Get(':interviewId')
+  findOne(
+    @Param('interviewId') interviewId: string,
+    @UserData() userData: UserInfo,
+  ) {
+    return this.questionService.findRoomQuestion(+interviewId, userData);
   }
 
   @Patch(':id')

--- a/backend/src/question/question.controller.ts
+++ b/backend/src/question/question.controller.ts
@@ -21,6 +21,7 @@ import { JwtGuard } from 'src/guards/jwtAuth.guard';
 import { UserData } from 'src/user/user.decorator';
 import { UserInfo } from 'src/interfaces/user.interface';
 import { CreateInterviewQuestionDto } from './dto/create-interview-question.dto';
+import { InterviewGuard } from 'src/guards/interview.guard';
 
 @Controller({ version: '1', path: 'question' })
 export class QuestionController {

--- a/backend/src/question/question.service.ts
+++ b/backend/src/question/question.service.ts
@@ -9,7 +9,10 @@ import { InterviewCategory } from 'src/entities/interviewCategory.entity';
 import { Category } from 'src/entities/category.entity';
 import { CreateQuestionDto } from './dto/create-question.dto';
 import { UpdateQuestionDto } from './dto/update-question.dto';
-import { UserInterviewStatus } from 'src/enum/userInterviewStatus.enum';
+import {
+  InterviewStatus,
+  UserInterviewStatus,
+} from 'src/enum/userInterviewStatus.enum';
 import { User } from 'src/entities/user.entity';
 import { QuestionType } from 'src/enum/questionType.enum';
 import { CreateUserQuestionDto } from './dto/create-user-question.dto';
@@ -147,6 +150,11 @@ export class QuestionService {
       const questions = this.extractQuestions(result);
       return questions;
     }
+
+    // 한 명이라도 종합 질문 조회하면 마감
+    await this.interviewRepository.update(interviewId, {
+      status: InterviewStatus.ENDED,
+    });
 
     // 1. 면접 분야 심플해당 파트에서 랜덤으로 가져오기
     const categoryData = await this.interviewCategoryRepository


### PR DESCRIPTION
관련 이슈: #180 

# 작업 내용
- 모의면접 선착순 신청 시 정원에 도달하면 마감 상태로 변경
- 면접의 종합 질문 조회 요청이 오면 해당 면접을 마감 상태로 변경
- 인터뷰 마감 여부를 확인하는 InterviewGuard 추가
  - 마감 상태의 면접에 신청 시 403 에러 응답
- 종합 피드백 조회 요청(post) 시 redis에 있는 피드백 데이터 삭제