### PR TITLE
hotfix: 면접 상태가 feedback에서 다시 end로 변경되는 경우 수정

### DIFF
--- a/backend/src/question/question.service.ts
+++ b/backend/src/question/question.service.ts
@@ -145,10 +145,15 @@ export class QuestionService {
       return questions;
     }
 
-    // 한 명이라도 종합 질문 조회하면 마감
-    await this.interviewRepository.update(interviewId, {
-      status: InterviewStatus.ENDED,
+    // 한 명이라도 종합 질문 조회하면 마감\
+    const [interview] = await this.interviewRepository.findBy({
+      id: interviewId,
     });
+    if (interview.status !== InterviewStatus.FEEDBACK) {
+      await this.interviewRepository.update(interviewId, {
+        status: InterviewStatus.ENDED,
+      });
+    }
 
     // 1. 면접 분야 심플해당 파트에서 랜덤으로 가져오기
     const categoryData = await this.interviewCategoryRepository


### PR DESCRIPTION
종합 피드백가기 버튼을 누르고 나가기를 누를 때 종합 질문 요청이 오는 현상이 있음. (리렌더링이 원인으로 생각됨)
이 때문에 면접 상태가 feedback(2)에서 다시 end(1)로 변경되는 경우가 생김.
feedback 상태가 아닐때만 end로 상태가 변경되도록 수정